### PR TITLE
Add ttl to the default k8s corefile in 1.3.1

### DIFF
--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -521,6 +521,7 @@ func TestDefault(t *testing.T) {
         pods insecure
         upstream
         fallthrough in-addr.arpa ip6.arpa
+        ttl 30
     }
     prometheus :9153
     forward . /etc/resolv.conf
@@ -537,6 +538,7 @@ func TestDefault(t *testing.T) {
         pods insecure
         upstream
         fallthrough in-addr.arpa ip6.arpa
+        ttl 30
     }
     prometheus :9153
     forward . /etc/resolv.conf

--- a/migration/versions.go
+++ b/migration/versions.go
@@ -575,6 +575,7 @@ var Versions = map[string]release{
         pods insecure
         upstream
         fallthrough in-addr.arpa ip6.arpa
+        ttl 30
     }
     prometheus :9153
     forward . *


### PR DESCRIPTION
It is part of the default for k8s in both kubeadm and kube-up