### PR TITLE
Allow single version status check

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -120,9 +120,6 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 		if v == toCoreDNSVersion {
 			break
 		}
-		if fromCoreDNSVersion == toCoreDNSVersion {
-			break
-		}
 	}
 	return notices, nil
 }

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/coredns/corefile-migration/migration/corefile"
 )
 
-// Deprecated returns a list of deprecation notifications affecting the guven Corefile.  Notifications are returned for
+// Deprecated returns a list of deprecation notifications affecting the given Corefile.  Notifications are returned for
 // any deprecated, removed, or ignored plugins/directives present in the Corefile.  Notifications are also returned for
 // any new default plugins that would be added in a migration.
 func Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
@@ -26,9 +26,6 @@ func Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]No
 }
 
 func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string) ([]Notice, error) {
-	if fromCoreDNSVersion == toCoreDNSVersion {
-		return nil, nil
-	}
 	err := validUpMigration(fromCoreDNSVersion, toCoreDNSVersion)
 	if err != nil {
 		return nil, err
@@ -40,7 +37,9 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 	notices := []Notice{}
 	v := fromCoreDNSVersion
 	for {
-		v = Versions[v].nextVersion
+		if fromCoreDNSVersion != toCoreDNSVersion {
+			v = Versions[v].nextVersion
+		}
 		for _, s := range cf.Servers {
 			for _, p := range s.Plugins {
 				vp, present := Versions[v].plugins[p.Name]
@@ -119,6 +118,9 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 			}
 		}
 		if v == toCoreDNSVersion {
+			break
+		}
+		if fromCoreDNSVersion == toCoreDNSVersion {
 			break
 		}
 	}
@@ -417,9 +419,13 @@ func validateVersion(fromCoreDNSVersion string) error {
 }
 
 func validUpMigration(fromCoreDNSVersion, toCoreDNSVersion string) error {
+
 	err := validateVersion(fromCoreDNSVersion)
 	if err != nil {
 		return err
+	}
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil
 	}
 	for next := Versions[fromCoreDNSVersion].nextVersion; next != ""; next = Versions[next].nextVersion {
 		if next != toCoreDNSVersion {

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -511,6 +511,26 @@ func TestUnsupported(t *testing.T) {
 			t.Errorf("expected to get '%v'; got '%v'", dep.ToString(), result[i].ToString())
 		}
 	}
+
+	expected = []Notice{
+		{Plugin: "route53", Severity: unsupported, Version: "1.3.1"},
+	}
+	result, err = Unsupported("1.3.1", "1.3.1", startCorefile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != len(expected) {
+		t.Fatalf("expected to find %v deprecations; got %v", len(expected), len(result))
+	}
+
+	for i, dep := range expected {
+		if result[i].ToString() != dep.ToString() {
+			t.Errorf("expected to get '%v'; got '%v'", dep.ToString(), result[i].ToString())
+		}
+	}
+
 }
 
 func TestDefault(t *testing.T) {
@@ -604,7 +624,7 @@ func TestValidUpMigration(t *testing.T) {
 		to        string
 		shouldErr bool
 	}{
-		{"1.3.1", "1.3.1", true},
+		{"1.3.1", "1.3.1", false},
 		{"1.3.1", "1.5.0", false},
 		{"1.5.0", "1.3.1", true},
 		{"banana", "1.5.0", true},


### PR DESCRIPTION
When fromVersion == toVersion, just check the status of the single version.
This, for instance, allows you to check a single version for unsupported plugins using Unsupported().

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>