### PR TITLE
Reduce lameduck to 5s

### DIFF
--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -37,7 +37,7 @@ func TestMigrate(t *testing.T) {
 			expectedCorefile: `.:53 {
     errors
     health {
-        lameduck 12s
+        lameduck 5s
     }
     ready
     kubernetes cluster.local in-addr.arpa ip6.arpa {
@@ -78,7 +78,7 @@ func TestMigrate(t *testing.T) {
 			expectedCorefile: `.:53 {
     errors
     health {
-        lameduck 12s
+        lameduck 5s
     }
     kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure

--- a/migration/versions.go
+++ b/migration/versions.go
@@ -101,7 +101,7 @@ var Versions = map[string]release{
 		defaultConf: `.:53 {
     errors
     health {
-        lameduck 12s
+        lameduck 5s
     }
     kubernetes * *** {
         pods insecure
@@ -132,7 +132,7 @@ var Versions = map[string]release{
 					"lameduck": {
 						status: newdefault,
 						add: func(c *corefile.Plugin) (*corefile.Plugin, error) {
-							return addOptionToPlugin(c, &corefile.Option{Name: "lameduck 12s"})
+							return addOptionToPlugin(c, &corefile.Option{Name: "lameduck 5s"})
 						},
 						downAction: removeOption,
 					},


### PR DESCRIPTION
The lameduck should be set to 5s, to align with the universally common default client DNS timeout of 5 seconds. 