### PR TITLE
Report unsupported options

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -62,7 +62,6 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 					continue
 				}
 				for _, o := range p.Options {
-					//vo, present := Versions[v].plugins[p.Name].namedOptions[o.Name]
 					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
 					if status == unsupported {
 						if present {
@@ -167,7 +166,6 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 				}
 				newOpts := []*corefile.Option{}
 				for _, o := range p.Options {
-					//vo, present := Versions[v].plugins[p.Name].namedOptions[o.Name]
 					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
 					if !present {
 						newOpts = append(newOpts, o)
@@ -294,7 +292,6 @@ func MigrateDown(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) (stri
 
 				newOpts := []*corefile.Option{}
 				for _, o := range p.Options {
-					//vo, present := Versions[v].plugins[p.Name].namedOptions[o.Name]
 					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
 					if !present {
 						newOpts = append(newOpts, o)

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -72,8 +72,6 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 							Option:     o.Name,
 							Severity:   status,
 							Version:    v,
-							ReplacedBy: vo.replacedBy,
-							Additional: vo.additional,
 						})
 						continue
 					}

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -44,17 +44,14 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 		for _, s := range cf.Servers {
 			for _, p := range s.Plugins {
 				vp, present := Versions[v].plugins[p.Name]
-				if status == unsupported {
-					if present {
-						continue
-					}
+				if status == unsupported && !present {
 					notices = append(notices, Notice{Plugin: p.Name, Severity: status, Version: v})
 					continue
 				}
 				if !present {
 					continue
 				}
-				if vp.status != "" && vp.status != newdefault {
+				if vp.status != "" && vp.status != newdefault && status != unsupported {
 					notices = append(notices, Notice{
 						Plugin:     p.Name,
 						Severity:   vp.status,

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -572,8 +572,12 @@ func TestDeprecated(t *testing.T) {
 
 func TestUnsupported(t *testing.T) {
 	startCorefile := `.:53 {
-    errors
-    health
+    errors {
+        consolidate
+    }
+    health {
+        lameduck
+    }
     kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure
         upstream

--- a/migration/plugins.go
+++ b/migration/plugins.go
@@ -1,0 +1,272 @@
+package migration
+
+import "github.com/coredns/corefile-migration/migration/corefile"
+
+var plugins = map[string]map[string]plugin{
+	"kubernetes": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod":       {},
+				"endpoint":           {},
+				"tls":                {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream":           {},
+				"ttl":                {},
+				"noendpoints":        {},
+				"transfer":           {},
+				"fallthrough":        {},
+				"ignore":             {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod":       {},
+				"endpoint":           {},
+				"tls":                {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream":           {},
+				"ttl":                {},
+				"noendpoints":        {},
+				"transfer":           {},
+				"fallthrough":        {},
+				"ignore":             {},
+				"kubeconfig":         {}, // new option
+			},
+		},
+		"v3": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": {},
+				"endpoint": { // new deprecation
+					status: deprecated,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream":           {},
+				"ttl":                {},
+				"noendpoints":        {},
+				"transfer":           {},
+				"fallthrough":        {},
+				"ignore":             {},
+			},
+		},
+		"v4": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": {},
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": { // new deprecation
+					status: deprecated,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+		"v5": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": { // new deprecation
+					status: deprecated,
+					action: removeOption,
+				},
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": {
+					status: ignored,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+		"v6": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": { // new removal
+					status: removed,
+					action: removeOption,
+				},
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": {
+					status: ignored,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+		"v7": plugin{
+			namedOptions: map[string]option{
+				// resyncperiod removed
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": {
+					status: ignored,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+	},
+
+	"errors": {
+		"v1": plugin{},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"consolidate": {},
+			},
+		},
+	},
+
+	"health": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"lameduck": {},
+			},
+		},
+		"v1 add lameduck": plugin{
+			namedOptions: map[string]option{
+				"lameduck": {
+					status: newdefault,
+					add: func(c *corefile.Plugin) (*corefile.Plugin, error) {
+						return addOptionToPlugin(c, &corefile.Option{Name: "lameduck 5s"})
+					},
+					downAction: removeOption,
+				},
+			},
+		},
+	},
+
+	"hosts": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"ttl":         {},
+				"no_reverse":  {},
+				"reload":      {},
+				"fallthrough": {},
+			},
+			patternOptions: map[string]option{
+				`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`:              {}, // close enough
+				`[0-9A-Fa-f]{1,4}:[:0-9A-Fa-f]+:[0-9A-Fa-f]{1,4}`: {}, // less close, but still close enough
+			},
+		},
+	},
+
+	"log": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"class": {},
+			},
+		},
+	},
+
+	"cache": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"success":  {},
+				"denial":   {},
+				"prefetch": {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"success":     {},
+				"denial":      {},
+				"prefetch":    {},
+				"serve_stale": {}, // new option
+			},
+		},
+	},
+
+	"forward": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"except":         {},
+				"force_tcp":      {},
+				"expire":         {},
+				"max_fails":      {},
+				"tls":            {},
+				"tls_servername": {},
+				"policy":         {},
+				"health_check":   {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"except":         {},
+				"force_tcp":      {},
+				"prefer_udp":     {},
+				"expire":         {},
+				"max_fails":      {},
+				"tls":            {},
+				"tls_servername": {},
+				"policy":         {},
+				"health_check":   {},
+			},
+		},
+	},
+
+	"k8s_external": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"apex": {},
+				"ttl":  {},
+			},
+		},
+	},
+}

--- a/migration/plugins.go
+++ b/migration/plugins.go
@@ -1,7 +1,40 @@
 package migration
 
-import "github.com/coredns/corefile-migration/migration/corefile"
+import (
+	"errors"
 
+	"github.com/coredns/corefile-migration/migration/corefile"
+)
+
+type plugin struct {
+	status         string
+	replacedBy     string
+	additional     string
+	namedOptions   map[string]option
+	patternOptions map[string]option
+	action         pluginActionFn // action affecting this plugin only
+	add            serverActionFn // action to add a new plugin to the server block
+	downAction     pluginActionFn // downgrade action affecting this plugin only
+}
+
+type option struct {
+	name       string
+	status     string
+	replacedBy string
+	additional string
+	action     optionActionFn // action affecting this option only
+	add        pluginActionFn // action to add the option to the plugin
+	downAction optionActionFn // downgrade action affecting this option only
+}
+
+type corefileAction func(*corefile.Corefile) (*corefile.Corefile, error)
+type serverActionFn func(*corefile.Server) (*corefile.Server, error)
+type pluginActionFn func(*corefile.Plugin) (*corefile.Plugin, error)
+type optionActionFn func(*corefile.Option) (*corefile.Option, error)
+
+// plugins holds a map of plugin names and their migration rules per "version".  "Version" here is meaningless outside
+// of the context of this code. Each change in options or migration actions for a plugin requires a new "version"
+// containing those new/removed options and migration actions. Plugins in CoreDNS are not versioned.
 var plugins = map[string]map[string]plugin{
 	"kubernetes": {
 		"v1": plugin{
@@ -269,4 +302,177 @@ var plugins = map[string]map[string]plugin{
 			},
 		},
 	},
+
+	"proxy": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"policy":       {},
+				"fail_timeout": {},
+				"max_fails":    {},
+				"health_check": {},
+				"except":       {},
+				"spray":        {},
+				"protocol": { // https_google option ignored
+					status: ignored,
+					action: proxyRemoveHttpsGoogleProtocol,
+				},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"policy":       {},
+				"fail_timeout": {},
+				"max_fails":    {},
+				"health_check": {},
+				"except":       {},
+				"spray":        {},
+				"protocol": { // https_google option removed
+					status: removed,
+					action: proxyRemoveHttpsGoogleProtocol,
+				},
+			},
+		},
+		"deprecation": plugin{ // proxy -> forward deprecation migration
+			status:       deprecated,
+			replacedBy:   "forward",
+			action:       proxyToForwardPluginAction,
+			namedOptions: proxyToForwardOptionsMigrations,
+		},
+		"removal": plugin{ // proxy -> forward forced migration
+			status:       removed,
+			replacedBy:   "forward",
+			action:       proxyToForwardPluginAction,
+			namedOptions: proxyToForwardOptionsMigrations,
+		},
+	},
+}
+
+
+func removePlugin(*corefile.Plugin) (*corefile.Plugin, error) { return nil, nil }
+func removeOption(*corefile.Option) (*corefile.Option, error) { return nil, nil }
+
+func renamePlugin(p *corefile.Plugin, to string) (*corefile.Plugin, error) {
+	p.Name = to
+	return p, nil
+}
+
+func addToServerBlockWithPlugins(sb *corefile.Server, newPlugin *corefile.Plugin, with []string) (*corefile.Server, error) {
+	if len(with) == 0 {
+		// add to all blocks
+		sb.Plugins = append(sb.Plugins, newPlugin)
+		return sb, nil
+	}
+	for _, p := range sb.Plugins {
+		for _, w := range with {
+			if w == p.Name {
+				// add to this block
+				sb.Plugins = append(sb.Plugins, newPlugin)
+				return sb, nil
+			}
+		}
+	}
+	return sb, nil
+}
+
+func addToKubernetesServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlockWithPlugins(sb, newPlugin, []string{"kubernetes"})
+}
+
+func addToForwardingServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlockWithPlugins(sb, newPlugin, []string{"forward", "proxy"})
+}
+
+func addToAllServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlockWithPlugins(sb, newPlugin, []string{})
+}
+
+func addOptionToPlugin(pl *corefile.Plugin, newOption *corefile.Option) (*corefile.Plugin, error) {
+	pl.Options = append(pl.Options, newOption)
+	return pl, nil
+}
+
+var proxyToForwardOptionsMigrations = map[string]option{
+	"policy": {
+		action: func(o *corefile.Option) (*corefile.Option, error) {
+			if len(o.Args) == 2 && o.Args[1] == "least_conn" {
+				o.Name = "force_tcp"
+				o.Args = nil
+			}
+			return o, nil
+		},
+	},
+	"except":       {},
+	"fail_timeout": {action: removeOption},
+	"max_fails":    {action: removeOption},
+	"health_check": {action: removeOption},
+	"spray":        {action: removeOption},
+	"protocol": {
+		action: func(o *corefile.Option) (*corefile.Option, error) {
+			if len(o.Args) >= 2 && o.Args[1] == "force_tcp" {
+				o.Name = "force_tcp"
+				o.Args = nil
+				return o, nil
+			}
+			return nil, nil
+		},
+	},
+}
+
+var proxyToForwardPluginAction = func(p *corefile.Plugin) (*corefile.Plugin, error) {
+	return renamePlugin(p, "forward")
+}
+
+var useFirstArgumentOnly = func(o *corefile.Option) (*corefile.Option, error) {
+	if len(o.Args) < 1 {
+		return o, nil
+	}
+	o.Args = o.Args[:1]
+	return o, nil
+}
+
+var proxyRemoveHttpsGoogleProtocol = func(o *corefile.Option) (*corefile.Option, error) {
+	if len(o.Args) > 0 && o.Args[0] == "https_google" {
+		return nil, nil
+	}
+	return o, nil
+}
+
+func breakForwardStubDomainsIntoServerBlocks(cf *corefile.Corefile) (*corefile.Corefile, error) {
+	for _, sb := range cf.Servers {
+		for j, fwd := range sb.Plugins {
+			if fwd.Name != "forward" {
+				continue
+			}
+			if len(fwd.Args) == 0 {
+				return nil, errors.New("found invalid forward plugin declaration")
+			}
+			if fwd.Args[0] == "." {
+				// dont move the default upstream
+				continue
+			}
+			if len(sb.DomPorts) != 1 {
+				return cf, errors.New("unhandled migration of multi-domain/port server block")
+			}
+			if sb.DomPorts[0] != "." && sb.DomPorts[0] != ".:53" {
+				return cf, errors.New("unhandled migration of non-default domain/port server block")
+			}
+
+			newSb := &corefile.Server{}                // create a new server block
+			newSb.DomPorts = []string{fwd.Args[0]}     // copy the forward zone to the server block domain
+			fwd.Args[0] = "."                          // the plugin's zone changes to "." for brevity
+			newSb.Plugins = append(newSb.Plugins, fwd) // add the plugin to its new server block
+
+			// Add appropriate addtl plugins to new server block
+			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "loop"})
+			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "errors"})
+			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "cache", Args: []string{"30"}})
+
+			//add new server block to corefile
+			cf.Servers = append(cf.Servers, newSb)
+
+			//remove the forward plugin from the original server block
+			sb.Plugins = append(sb.Plugins[:j], sb.Plugins[j+1:]...)
+		}
+	}
+	return cf, nil
 }

--- a/migration/versions.go
+++ b/migration/versions.go
@@ -1,30 +1,8 @@
 package migration
 
 import (
-	"errors"
 	"github.com/coredns/corefile-migration/migration/corefile"
 )
-
-type plugin struct {
-	status         string
-	replacedBy     string
-	additional     string
-	namedOptions   map[string]option
-	patternOptions map[string]option
-	action         pluginActionFn // action affecting this plugin only
-	add            serverActionFn // action to add a new plugin to the server block
-	downAction     pluginActionFn // downgrade action affecting this plugin only
-}
-
-type option struct {
-	name       string
-	status     string
-	replacedBy string
-	additional string
-	action     optionActionFn // action affecting this option only
-	add        pluginActionFn // action to add the option to the plugin
-	downAction optionActionFn // downgrade action affecting this option only
-}
 
 type release struct {
 	k8sReleases    []string
@@ -48,54 +26,7 @@ type release struct {
 	defaultConf string
 }
 
-type corefileAction func(*corefile.Corefile) (*corefile.Corefile, error)
-type serverActionFn func(*corefile.Server) (*corefile.Server, error)
-type pluginActionFn func(*corefile.Plugin) (*corefile.Plugin, error)
-type optionActionFn func(*corefile.Option) (*corefile.Option, error)
-
-func removePlugin(*corefile.Plugin) (*corefile.Plugin, error) { return nil, nil }
-func removeOption(*corefile.Option) (*corefile.Option, error) { return nil, nil }
-
-func renamePlugin(p *corefile.Plugin, to string) (*corefile.Plugin, error) {
-	p.Name = to
-	return p, nil
-}
-
-func addToServerBlockWithPlugins(sb *corefile.Server, newPlugin *corefile.Plugin, with []string) (*corefile.Server, error) {
-	if len(with) == 0 {
-		// add to all blocks
-		sb.Plugins = append(sb.Plugins, newPlugin)
-		return sb, nil
-	}
-	for _, p := range sb.Plugins {
-		for _, w := range with {
-			if w == p.Name {
-				// add to this block
-				sb.Plugins = append(sb.Plugins, newPlugin)
-				return sb, nil
-			}
-		}
-	}
-	return sb, nil
-}
-
-func addToKubernetesServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
-	return addToServerBlockWithPlugins(sb, newPlugin, []string{"kubernetes"})
-}
-
-func addToForwardingServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
-	return addToServerBlockWithPlugins(sb, newPlugin, []string{"forward", "proxy"})
-}
-
-func addToAllServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
-	return addToServerBlockWithPlugins(sb, newPlugin, []string{})
-}
-
-func addOptionToPlugin(pl *corefile.Plugin, newOption *corefile.Option) (*corefile.Plugin, error) {
-	pl.Options = append(pl.Options, newOption)
-	return pl, nil
-}
-
+// Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
 	"1.6.6": {
 		priorVersion:   "1.6.5",
@@ -119,20 +50,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v7"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v2"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v2"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.5": {
@@ -158,20 +89,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": plugins["errors"]["v2"],
-			"log":    plugins["log"]["v1"],
-			"health": plugins["health"]["v1 add lameduck"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v7"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1 add lameduck"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.4": {
@@ -179,20 +110,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.3",
 		dockerImageSHA: "493ee88e1a92abebac67cbd4b5658b4730e0f33512461442d8d9214ea6734a9b",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v7"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.3": {
@@ -200,20 +131,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.2",
 		dockerImageSHA: "cfa7236dab4e3860881fdf755880ff8361e42f6cba2e3775ae48e2d46d22f7ba",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v7"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.2": {
@@ -237,20 +168,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v7"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.1": {
@@ -258,20 +189,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.0",
 		dockerImageSHA: "9ae3b6fcac4ee821362277de6bd8fd2236fa7d3e19af2ef0406d80b595620a7a",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v7"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.0": {
@@ -279,20 +210,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.2",
 		dockerImageSHA: "263d03f2b889a75a0b91e035c2a14d45d7c1559c53444c5f7abf3a76014b779d",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v6"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v6"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.5.2": {
@@ -300,20 +231,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.1",
 		dockerImageSHA: "586d15ec14911ee680ac9c5af20ff24b9d1412fbbf0e05862ee1f5c37baa65b2",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v5"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v5"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.5.1": {
@@ -321,20 +252,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.0",
 		dockerImageSHA: "451817637035535ae1fc8639753b453fa4b781d0dea557d5da5cb3c131e62ef5",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v5"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v5"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.5.0": {
@@ -344,7 +275,7 @@ var Versions = map[string]release{
 		plugins: map[string]plugin{
 			"errors": plugins["errors"]["v2"],
 			"log":    plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
+			"health": plugins["health"]["v1"],
 			"ready": {
 				status: newdefault,
 				add: func(c *corefile.Server) (*corefile.Server, error) {
@@ -352,22 +283,17 @@ var Versions = map[string]release{
 				},
 				downAction: removePlugin,
 			},
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v5"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v5"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				status:       removed,
-				replacedBy:   "forward",
-				action:       proxyToForwardPluginAction,
-				namedOptions: proxyToForwardOptionsMigrations,
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["removal"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 		postProcess: breakForwardStubDomainsIntoServerBlocks,
 	},
@@ -376,25 +302,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.3.1",
 		dockerImageSHA: "70a92e9f6fc604f9b629ca331b6135287244a86612f550941193ec7e12759417",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v4"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v4"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				status:       deprecated,
-				replacedBy:   "forward",
-				action:       proxyToForwardPluginAction,
-				namedOptions: proxyToForwardOptionsMigrations,
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["deprecation"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 		postProcess: breakForwardStubDomainsIntoServerBlocks,
 	},
@@ -420,30 +341,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v3"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v3"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["v2"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.3.0": {
@@ -451,30 +362,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.6",
 		dockerImageSHA: "e030773c7fee285435ed7fc7623532ee54c4c1c4911fb24d95cd0170a8a768bc",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v2"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v2"],
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v2"],
 			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
-			"hosts":       plugins["hosts"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["v2"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.6": {
@@ -503,24 +404,14 @@ var Versions = map[string]release{
 					"consolidate": {},
 				},
 			},
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v2"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
@@ -532,25 +423,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.4",
 		dockerImageSHA: "33c8da20b887ae12433ec5c40bfddefbbfa233d5ce11fb067122e68af30291d6",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v2"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
@@ -562,25 +443,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.3",
 		dockerImageSHA: "a0d40ad961a714c699ee7b61b77441d165f6252f9fb84ac625d04a8d8554c0ec",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v2"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
@@ -592,25 +463,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.2",
 		dockerImageSHA: "12f3cab301c826978fac736fd40aca21ac023102fd7f4aa6b4341ae9ba89e90e",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v2"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
@@ -638,25 +499,15 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v1"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
@@ -668,25 +519,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.0",
 		dockerImageSHA: "fb129c6a7c8912bc6d9cc4505e1f9007c5565ceb1aa6369750e60cc79771a244",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
+			"errors":     plugins["errors"]["v1"],
+			"log":        plugins["log"]["v1"],
+			"health":     plugins["health"]["v1"],
+			"autopath":   {},
 			"kubernetes": plugins["kubernetes"]["v1"],
 			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"proxy":      plugins["proxy"]["v2"],
+			"forward":    plugins["forward"]["v2"],
+			"cache":      plugins["cache"]["v1"],
 			"loop": {
 				status: newdefault,
 				add: func(s *corefile.Server) (*corefile.Server, error) {
@@ -704,28 +545,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.1.4",
 		dockerImageSHA: "ae69a32f8cc29a3e2af9628b6473f24d3e977950a2cb62ce8911478a61215471",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol": {
-						status: removed,
-						action: proxyRemoveHttpsGoogleProtocol,
-					},
-				},
-			},
-			"forward": plugins["forward"]["v2"],
-			"cache": plugins["cache"]["v1"],
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v1"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"reload":      {},
 			"loadbalance": {},
 			"hosts":       plugins["hosts"]["v1"],
@@ -736,28 +564,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.1.3",
 		dockerImageSHA: "463c7021141dd3bfd4a75812f4b735ef6aadc0253a128f15ffe16422abe56e50",
 		plugins: map[string]plugin{
-			"errors":   plugins["errors"]["v1"],
-			"log":      plugins["log"]["v1"],
-			"health":   plugins["health"]["v1"],
-			"autopath": {},
-			"kubernetes": plugins["kubernetes"]["v1"],
-			"prometheus": {},
-			"proxy": {
-				namedOptions: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol": {
-						status: ignored,
-						action: proxyRemoveHttpsGoogleProtocol,
-					},
-				},
-			},
-			"forward": plugins["forward"]["v1"],
-			"cache": plugins["cache"]["v1"],
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v1"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v1"],
+			"forward":     plugins["forward"]["v1"],
+			"cache":       plugins["cache"]["v1"],
 			"reload":      {},
 			"loadbalance": {},
 			"hosts":       plugins["hosts"]["v1"],
@@ -780,90 +595,4 @@ var Versions = map[string]release{
     cache 30
     reload
 }`},
-}
-
-var proxyToForwardOptionsMigrations = map[string]option{
-	"policy": {
-		action: func(o *corefile.Option) (*corefile.Option, error) {
-			if len(o.Args) == 2 && o.Args[1] == "least_conn" {
-				o.Name = "force_tcp"
-				o.Args = nil
-			}
-			return o, nil
-		},
-	},
-	"except":       {},
-	"fail_timeout": {action: removeOption},
-	"max_fails":    {action: removeOption},
-	"health_check": {action: removeOption},
-	"spray":        {action: removeOption},
-	"protocol": {
-		action: func(o *corefile.Option) (*corefile.Option, error) {
-			if len(o.Args) >= 2 && o.Args[1] == "force_tcp" {
-				o.Name = "force_tcp"
-				o.Args = nil
-				return o, nil
-			}
-			return nil, nil
-		},
-	},
-}
-
-var proxyToForwardPluginAction = func(p *corefile.Plugin) (*corefile.Plugin, error) {
-	return renamePlugin(p, "forward")
-}
-
-var useFirstArgumentOnly = func(o *corefile.Option) (*corefile.Option, error) {
-	if len(o.Args) < 1 {
-		return o, nil
-	}
-	o.Args = o.Args[:1]
-	return o, nil
-}
-
-var proxyRemoveHttpsGoogleProtocol = func(o *corefile.Option) (*corefile.Option, error) {
-	if len(o.Args) > 0 && o.Args[0] == "https_google" {
-		return nil, nil
-	}
-	return o, nil
-}
-
-func breakForwardStubDomainsIntoServerBlocks(cf *corefile.Corefile) (*corefile.Corefile, error) {
-	for _, sb := range cf.Servers {
-		for j, fwd := range sb.Plugins {
-			if fwd.Name != "forward" {
-				continue
-			}
-			if len(fwd.Args) == 0 {
-				return nil, errors.New("found invalid forward plugin declaration")
-			}
-			if fwd.Args[0] == "." {
-				// dont move the default upstream
-				continue
-			}
-			if len(sb.DomPorts) != 1 {
-				return cf, errors.New("unhandled migration of multi-domain/port server block")
-			}
-			if sb.DomPorts[0] != "." && sb.DomPorts[0] != ".:53" {
-				return cf, errors.New("unhandled migration of non-default domain/port server block")
-			}
-
-			newSb := &corefile.Server{}                // create a new server block
-			newSb.DomPorts = []string{fwd.Args[0]}     // copy the forward zone to the server block domain
-			fwd.Args[0] = "."                          // the plugin's zone changes to "." for brevity
-			newSb.Plugins = append(newSb.Plugins, fwd) // add the plugin to its new server block
-
-			// Add appropriate addtl plugins to new server block
-			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "loop"})
-			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "errors"})
-			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "cache", Args: []string{"30"}})
-
-			//add new server block to corefile
-			cf.Servers = append(cf.Servers, newSb)
-
-			//remove the forward plugin from the original server block
-			sb.Plugins = append(sb.Plugins[:j], sb.Plugins[j+1:]...)
-		}
-	}
-	return cf, nil
 }

--- a/migration/versions.go
+++ b/migration/versions.go
@@ -119,75 +119,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health": {
-				namedOptions: map[string]option{},
-			},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v2"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.5": {
@@ -213,83 +158,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health": {
-				namedOptions: map[string]option{
-					"lameduck": {
-						status: newdefault,
-						add: func(c *corefile.Plugin) (*corefile.Plugin, error) {
-							return addOptionToPlugin(c, &corefile.Option{Name: "lameduck 5s"})
-						},
-						downAction: removeOption,
-					},
-				},
-			},
+			"errors": plugins["errors"]["v2"],
+			"log":    plugins["log"]["v1"],
+			"health": plugins["health"]["v1 add lameduck"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.4": {
@@ -297,73 +179,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.3",
 		dockerImageSHA: "493ee88e1a92abebac67cbd4b5658b4730e0f33512461442d8d9214ea6734a9b",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.3": {
@@ -371,73 +200,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.2",
 		dockerImageSHA: "cfa7236dab4e3860881fdf755880ff8361e42f6cba2e3775ae48e2d46d22f7ba",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.2": {
@@ -461,73 +237,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.1": {
@@ -535,73 +258,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.0",
 		dockerImageSHA: "9ae3b6fcac4ee821362277de6bd8fd2236fa7d3e19af2ef0406d80b595620a7a",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.6.0": {
@@ -609,77 +279,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.2",
 		dockerImageSHA: "263d03f2b889a75a0b91e035c2a14d45d7c1559c53444c5f7abf3a76014b779d",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod": {
-						status: removed,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v6"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.5.2": {
@@ -687,77 +300,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.1",
 		dockerImageSHA: "586d15ec14911ee680ac9c5af20ff24b9d1412fbbf0e05862ee1f5c37baa65b2",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v5"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.5.1": {
@@ -765,77 +321,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.0",
 		dockerImageSHA: "451817637035535ae1fc8639753b453fa4b781d0dea557d5da5cb3c131e62ef5",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready":    {},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v5"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.5.0": {
@@ -843,17 +342,9 @@ var Versions = map[string]release{
 		priorVersion:   "1.4.0",
 		dockerImageSHA: "e83beb5e43f8513fa735e77ffc5859640baea30a882a11cc75c4c3244a737d3c",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health": {},
+			"errors": plugins["errors"]["v2"],
+			"log":    plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"ready": {
 				status: newdefault,
 				add: func(c *corefile.Server) (*corefile.Server, error) {
@@ -862,39 +353,8 @@ var Versions = map[string]release{
 				downAction: removePlugin,
 			},
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v5"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				status:       removed,
@@ -902,30 +362,12 @@ var Versions = map[string]release{
 				action:       proxyToForwardPluginAction,
 				namedOptions: proxyToForwardOptionsMigrations,
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 		postProcess: breakForwardStubDomainsIntoServerBlocks,
 	},
@@ -934,48 +376,12 @@ var Versions = map[string]release{
 		priorVersion:   "1.3.1",
 		dockerImageSHA: "70a92e9f6fc604f9b629ca331b6135287244a86612f550941193ec7e12759417",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod": {},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v4"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				status:       deprecated,
@@ -983,30 +389,12 @@ var Versions = map[string]release{
 				action:       proxyToForwardPluginAction,
 				namedOptions: proxyToForwardOptionsMigrations,
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 		postProcess: breakForwardStubDomainsIntoServerBlocks,
 	},
@@ -1032,45 +420,12 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod": {},
-					"endpoint": {
-						status: deprecated,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"k8s_external": {
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v3"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1083,30 +438,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.3.0": {
@@ -1114,43 +451,12 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.6",
 		dockerImageSHA: "e030773c7fee285435ed7fc7623532ee54c4c1c4911fb24d95cd0170a8a768bc",
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v2"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"k8s_external": {
-				downAction: removePlugin,
-				namedOptions: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v2"],
+			"k8s_external": plugins["k8s_external"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1163,30 +469,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.6": {
@@ -1215,31 +503,10 @@ var Versions = map[string]release{
 					"consolidate": {},
 				},
 			},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v2"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1252,30 +519,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.5": {
@@ -1283,32 +532,11 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.4",
 		dockerImageSHA: "33c8da20b887ae12433ec5c40bfddefbbfa233d5ce11fb067122e68af30291d6",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v2"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1321,30 +549,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.4": {
@@ -1352,32 +562,11 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.3",
 		dockerImageSHA: "a0d40ad961a714c699ee7b61b77441d165f6252f9fb84ac625d04a8d8554c0ec",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v2"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1390,30 +579,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.3": {
@@ -1421,32 +592,11 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.2",
 		dockerImageSHA: "12f3cab301c826978fac736fd40aca21ac023102fd7f4aa6b4341ae9ba89e90e",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v2"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1459,30 +609,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.2": {
@@ -1506,31 +638,11 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1543,30 +655,12 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.1": {
@@ -1574,31 +668,11 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.0",
 		dockerImageSHA: "fb129c6a7c8912bc6d9cc4505e1f9007c5565ceb1aa6369750e60cc79771a244",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1611,26 +685,8 @@ var Versions = map[string]release{
 					"protocol":     {},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"loop": {
 				status: newdefault,
 				add: func(s *corefile.Server) (*corefile.Server, error) {
@@ -1640,7 +696,7 @@ var Versions = map[string]release{
 			},
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.2.0": {
@@ -1648,31 +704,11 @@ var Versions = map[string]release{
 		priorVersion:   "1.1.4",
 		dockerImageSHA: "ae69a32f8cc29a3e2af9628b6473f24d3e977950a2cb62ce8911478a61215471",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1688,29 +724,11 @@ var Versions = map[string]release{
 					},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v2"],
+			"cache": plugins["cache"]["v1"],
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.1.4": {
@@ -1718,31 +736,11 @@ var Versions = map[string]release{
 		priorVersion:   "1.1.3",
 		dockerImageSHA: "463c7021141dd3bfd4a75812f4b735ef6aadc0253a128f15ffe16422abe56e50",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				namedOptions: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
+			"errors":   plugins["errors"]["v1"],
+			"log":      plugins["log"]["v1"],
+			"health":   plugins["health"]["v1"],
 			"autopath": {},
-			"kubernetes": {
-				namedOptions: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"kubernetes": plugins["kubernetes"]["v1"],
 			"prometheus": {},
 			"proxy": {
 				namedOptions: map[string]option{
@@ -1758,28 +756,11 @@ var Versions = map[string]release{
 					},
 				},
 			},
-			"forward": {
-				namedOptions: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				namedOptions: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"forward": plugins["forward"]["v1"],
+			"cache": plugins["cache"]["v1"],
 			"reload":      {},
 			"loadbalance": {},
-			"hosts":       hostPluginv1,
+			"hosts":       plugins["hosts"]["v1"],
 		},
 	},
 	"1.1.3": {
@@ -1799,19 +780,6 @@ var Versions = map[string]release{
     cache 30
     reload
 }`},
-}
-
-var hostPluginv1 = plugin{
-	namedOptions: map[string]option{
-		"ttl":         {},
-		"no_reverse":  {},
-		"reload":      {},
-		"fallthrough": {},
-	},
-	patternOptions: map[string]option{
-		`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`:              {}, // close enough
-		`[0-9A-Fa-f]{1,4}:[:0-9A-Fa-f]+:[0-9A-Fa-f]{1,4}`: {}, // less close, but still close enough
-	},
 }
 
 var proxyToForwardOptionsMigrations = map[string]option{

--- a/migration/versions.go
+++ b/migration/versions.go
@@ -4,12 +4,13 @@ import (
 	"github.com/coredns/corefile-migration/migration/corefile"
 )
 
+// release holds information pertaining to a single CoreDNS release
 type release struct {
-	k8sReleases    []string
-	nextVersion    string
-	priorVersion   string
-	dockerImageSHA string
-	plugins        map[string]plugin // list of plugins with deprecation status and migration actions
+	k8sReleases    []string          // a list of K8s versions that deploy this CoreDNS release by default
+	nextVersion    string            // the next CoreDNS version
+	priorVersion   string            // the prior CoreDNS version
+	dockerImageSHA string            // the docker image SHA for this release
+	plugins        map[string]plugin // map of plugins with deprecation status and migration actions for this release
 
 	// postProcess is a post processing action to take on the corefile as a whole.  Used for complex migration
 	//   tasks that dont fit well into the modular plugin/option migration framework. For example, when the


### PR DESCRIPTION
* Report unsupported options in the notifications returned by Unsupported(). This will produce a notice like: Option "blahblah" in plugin "cache" is unsupported by this migration tool in 1.6.0.
* Add missing options for some existing supported plugins.  Some valid options were missing from plugin definitions in the Versions map.
* Refactor of versions.go: split into two files to reduce code replication.
  1. versions.go containing which version of each plugin per CoreDNS release
  2. plugins.go: containing definitions of plugin versions and migrations