### PR TITLE
Correct default configs, add missing k8s release info

### DIFF
--- a/migration/versions.go
+++ b/migration/versions.go
@@ -100,24 +100,6 @@ var Versions = map[string]release{
 	"1.6.6": {
 		priorVersion:   "1.6.5",
 		dockerImageSHA: "41bee6992c2ed0f4628fcef75751048927bcd6b1cee89c79f6acb63ca5474d5a",
-		defaultConf: `.:53 {
-    errors
-    health {
-        lameduck 5s
-    }
-    kubernetes * *** {
-        pods insecure
-        upstream
-        fallthrough in-addr.arpa ip6.arpa
-        ttl 30
-    }
-    prometheus :9153
-    forward . *
-    cache 30
-    loop
-    reload
-    loadbalance
-}`,
 		plugins: map[string]plugin{
 			"errors": {
 				namedOptions: map[string]option{
@@ -193,6 +175,7 @@ var Versions = map[string]release{
 	"1.6.5": {
 		nextVersion:    "1.6.6",
 		priorVersion:   "1.6.4",
+		k8sReleases:    []string{"1.17"},
 		dockerImageSHA: "7ec975f167d815311a7136c32e70735f0d00b73781365df1befd46ed35bd4fe7",
 		defaultConf: `.:53 {
     errors
@@ -201,7 +184,6 @@ var Versions = map[string]release{
     }
     kubernetes * *** {
         pods insecure
-        upstream
         fallthrough in-addr.arpa ip6.arpa
         ttl 30
     }
@@ -443,13 +425,13 @@ var Versions = map[string]release{
 	"1.6.2": {
 		nextVersion:    "1.6.3",
 		priorVersion:   "1.6.1",
+		k8sReleases:    []string{"1.16"},
 		dockerImageSHA: "12eb885b8685b1b13a04ecf5c23bc809c2e57917252fd7b0be9e9c00644e8ee5",
 		defaultConf: `.:53 {
     errors
     health
     kubernetes * *** {
         pods insecure
-        upstream
         fallthrough in-addr.arpa ip6.arpa
         ttl 30
     }


### PR DESCRIPTION

Removes default config template from 1.6.6 (copied forward by mistake).
Remove `upstream` from default config template as of 1.16
Adds k8s release info, missing for 1.16 and 1.17.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>