### PR TITLE
replace stray manual errors plugin def with v2

### DIFF
--- a/migration/versions.go
+++ b/migration/versions.go
@@ -382,11 +382,7 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				namedOptions: map[string]option{
-					"consolidate": {},
-				},
-			},
+			"errors":      plugins["errors"]["v2"],
 			"log":         plugins["log"]["v1"],
 			"health":      plugins["health"]["v1"],
 			"autopath":    {},


### PR DESCRIPTION
Replace stray manual errors plugin def with v2, missed in prior PR.