### PR TITLE
Fix proxy to forward plugin migration

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -68,10 +68,10 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 							continue
 						}
 						notices = append(notices, Notice{
-							Plugin:     p.Name,
-							Option:     o.Name,
-							Severity:   status,
-							Version:    v,
+							Plugin:   p.Name,
+							Option:   o.Name,
+							Severity: status,
+							Version:  v,
 						})
 						continue
 					}
@@ -152,16 +152,6 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 					newPlugs = append(newPlugs, p)
 					continue
 				}
-				if vp.action != nil {
-					p, err := vp.action(p)
-					if err != nil {
-						return "", err
-					}
-					if p == nil {
-						// remove plugin, skip options processing
-						continue
-					}
-				}
 				newOpts := []*corefile.Option{}
 				for _, o := range p.Options {
 					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
@@ -186,6 +176,16 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 						continue
 					}
 					newOpts = append(newOpts, o)
+				}
+				if vp.action != nil {
+					p, err := vp.action(p)
+					if err != nil {
+						return "", err
+					}
+					if p == nil {
+						// remove plugin, skip options processing
+						continue
+					}
 				}
 				newPlug := &corefile.Plugin{
 					Name:    p.Name,

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -14,6 +14,46 @@ func TestMigrate(t *testing.T) {
 		expectedCorefile string
 	}{
 		{
+			name:         "replace/remove proxy options",
+			fromVersion:  "1.3.1",
+			toVersion:    "1.5.0",
+			deprecations: true,
+			startCorefile: `.:53 {
+    errors
+    health
+    loop
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    proxy . /etc/resolv.conf {
+       max_fails
+    }
+    cache 30
+    reload
+    loadbalance
+}
+`,
+			expectedCorefile: `.:53 {
+    errors
+    health
+    loop
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . /etc/resolv.conf
+    cache 30
+    reload
+    loadbalance
+    ready
+}
+`,
+		},
+		{
+
 			name:         "Add lameduck option to health plugin",
 			fromVersion:  "1.6.2",
 			toVersion:    "1.6.6",


### PR DESCRIPTION
Proxy to forward plugin migration was not working as intended due to plugin action replacing the plugin name beforehand, causing plugin options to not match 