### PR TITLE
Exports ValidUpMigration to be used publicly

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -27,7 +27,7 @@ func Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]No
 }
 
 func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string) ([]Notice, error) {
-	err := validUpMigration(fromCoreDNSVersion, toCoreDNSVersion)
+	err := ValidUpMigration(fromCoreDNSVersion, toCoreDNSVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 	if fromCoreDNSVersion == toCoreDNSVersion {
 		return corefileStr, nil
 	}
-	err := validUpMigration(fromCoreDNSVersion, toCoreDNSVersion)
+	err := ValidUpMigration(fromCoreDNSVersion, toCoreDNSVersion)
 	if err != nil {
 		return "", err
 	}
@@ -404,14 +404,7 @@ func ValidVersions() []string {
 	return vStrs
 }
 
-func validateVersion(fromCoreDNSVersion string) error {
-	if _, ok := Versions[fromCoreDNSVersion]; !ok {
-		return fmt.Errorf("start version '%v' not supported", fromCoreDNSVersion)
-	}
-	return nil
-}
-
-func validUpMigration(fromCoreDNSVersion, toCoreDNSVersion string) error {
+func ValidUpMigration(fromCoreDNSVersion, toCoreDNSVersion string) error {
 
 	err := validateVersion(fromCoreDNSVersion)
 	if err != nil {
@@ -427,6 +420,13 @@ func validUpMigration(fromCoreDNSVersion, toCoreDNSVersion string) error {
 		return nil
 	}
 	return fmt.Errorf("cannot migrate up to '%v' from '%v'", toCoreDNSVersion, fromCoreDNSVersion)
+}
+
+func validateVersion(fromCoreDNSVersion string) error {
+	if _, ok := Versions[fromCoreDNSVersion]; !ok {
+		return fmt.Errorf("start version '%v' not supported", fromCoreDNSVersion)
+	}
+	return nil
 }
 
 func validDownMigration(fromCoreDNSVersion, toCoreDNSVersion string) error {

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -995,7 +995,7 @@ func TestValidUpMigration(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := validUpMigration(tc.from, tc.to)
+		err := ValidUpMigration(tc.from, tc.to)
 
 		if !tc.shouldErr && err != nil {
 			t.Errorf("expected '%v' to '%v' to be valid versions.", tc.from, tc.to)


### PR DESCRIPTION
Hello, 

I'm working on [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/2620) for cluster-api and wanted to send out this PR so `ValidUpMigration()` can be exported. 

I understand that `Migrate()` was already calling the `validUpMigration()` but we're implementing something that will validate the version in a webhook before it gets to the point where Migrate is called (much later on in a different controller). 