### PR TITLE
Re-escape whitespace in arguments

### DIFF
--- a/migration/corefile/corefile.go
+++ b/migration/corefile/corefile.go
@@ -76,7 +76,7 @@ func (c *Corefile) ToString() (out string) {
 }
 
 func (s *Server) ToString() (out string) {
-	str := strings.Join(s.DomPorts, " ")
+	str := strings.Join(escapeArgs(s.DomPorts), " ")
 	strs := []string{}
 	for _, p := range s.Plugins {
 		strs = append(strs, strings.Repeat(" ", indent)+p.ToString())
@@ -88,7 +88,7 @@ func (s *Server) ToString() (out string) {
 }
 
 func (p *Plugin) ToString() (out string) {
-	str := strings.Join(append([]string{p.Name}, p.Args...), " ")
+	str := strings.Join(append([]string{p.Name}, escapeArgs(p.Args)...), " ")
 	strs := []string{}
 	for _, o := range p.Options {
 		strs = append(strs, strings.Repeat(" ", indent*2)+o.ToString())
@@ -100,8 +100,24 @@ func (p *Plugin) ToString() (out string) {
 }
 
 func (o *Option) ToString() (out string) {
-	str := strings.Join(append([]string{o.Name}, o.Args...), " ")
+	str := strings.Join(append([]string{o.Name}, escapeArgs(o.Args)...), " ")
 	return str
+}
+
+// escapeArgs returns the arguments list escaping and wrapping any argument containing whitespace in quotes
+func escapeArgs(args []string) []string {
+	var escapedArgs []string
+	for _, a := range args {
+		// if there is white space, wrap argument with quotes
+		if len(strings.Fields(a)) > 1 {
+			// escape quotes
+			a = strings.Replace(a, "\"", "\\\"", -1)
+			// wrap with quotes
+			a = "\"" + a + "\""
+		}
+		escapedArgs = append(escapedArgs, a)
+	}
+	return escapedArgs
 }
 
 func (s *Server) FindMatch(def []*Server) (*Server, bool) {

--- a/migration/corefile/corefile_test.go
+++ b/migration/corefile/corefile_test.go
@@ -28,7 +28,12 @@ func TestCorefile(t *testing.T) {
 
 "exam ple.com:53" {
     exampleplug "arg \"1\"" {
-        option1 "my arg1" arg2 "arg \"three\""
+        option1 "my arg1" arg2 "arg \"three\"" "arg \4"
+    }
+    template ANY A foo.bar.com {
+        match "^([^.]+).A foo.bar.com"
+        answer "{{ .Name }} 59 IN CNAME foo2.bar.com"
+        upstream 127.0.0.1:53
     }
 }
 `

--- a/migration/corefile/corefile_test.go
+++ b/migration/corefile/corefile_test.go
@@ -25,6 +25,12 @@ func TestCorefile(t *testing.T) {
 .:5353 {
     proxy . /etc/resolv.conf
 }
+
+"exam ple.com:53" {
+    exampleplug "arg \"1\"" {
+        option1 "my arg1" arg2 "arg \"three\""
+    }
+}
 `
 	c, err := New(startCorefile)
 


### PR DESCRIPTION
re-escape whitespace in ...

* server domains
* plugin arguments
* option arguments

For now, assuming that plugin names and option names cannot have whitespace.

Fixes #42

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>