### PR TITLE
Add codecov target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: null
+    patch: false
+    changes: false


### PR DESCRIPTION
Adds a codecov.yml config similar to coredns/coredns so that commit status is a success as long as coverage > 75%.