### PR TITLE
Add checks for non-migration case

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -20,12 +20,18 @@ import (
 // any deprecated, removed, or ignored plugins/directives present in the Corefile.  Notifications are also returned for
 // any new default plugins that would be added in a migration.
 func Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	return getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, SevAll)
 }
 
 // Unsupported returns a list notifications of plugins/options that are not handled supported by this migration tool,
 // but may still be valid in CoreDNS.
 func Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	return getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, SevUnsupported)
 }
 

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -858,9 +858,7 @@ func TestUnsupported(t *testing.T) {
 `,
 			fromVersion: "1.3.1",
 			toVersion:   "1.3.1",
-			expected: []Notice{
-				{Plugin: "route53", Severity: SevUnsupported, Version: "1.3.1"},
-			},
+			expected:    []Notice{},
 		},
 		{
 			name: "Wrong plugin option",


### PR DESCRIPTION
Add checks for the non-migration case - i.e. when the start version  is the same as the end version.

This is done to accommodate clients that don't make this check before calling `Supported` or `Deprecated`.